### PR TITLE
Replace deprecated use of Display.show() with the new Display.root_group property for CircuitPython 9 and newer

### DIFF
--- a/code.py
+++ b/code.py
@@ -82,6 +82,9 @@ image_grid = displayio.TileGrid(image_bit, pixel_shader=image_pal,
 group = displayio.Group()
 group.append(image_grid)
 
+# deprecated method, only use with CircuitPython 8 or older
+# display.show(group)
+# new property to be used with CircuitPyhton 9 and newer
 display.root_group = group
 
 # time.monotonic() is an internal clock value returned in fractional seconds

--- a/code.py
+++ b/code.py
@@ -82,7 +82,7 @@ image_grid = displayio.TileGrid(image_bit, pixel_shader=image_pal,
 group = displayio.Group()
 group.append(image_grid)
 
-display.show(group)
+display.root_group = group
 
 # time.monotonic() is an internal clock value returned in fractional seconds
 time_value = 0 #  time.monotonic() holder


### PR DESCRIPTION
Someone in the Adafruit discord was trying to use this code today, and ran into the error.

I thought you'd like to do an update, since it's such a nice project for beginners! 